### PR TITLE
Replace call to sudo with mocks

### DIFF
--- a/fixture.js
+++ b/fixture.js
@@ -1,3 +1,0 @@
-'use strict';
-var sudoBlock = require('./sudo-block');
-sudoBlock('test');

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "mocha": "~1.9.0",
-    "sudo": "~1.0.3"
+    "sinon": "~1.7.3"
   },
   "engines": {
     "node": ">=0.8.0"

--- a/test.js
+++ b/test.js
@@ -1,26 +1,36 @@
 /*global describe, it */
 'use strict';
 var assert = require('assert');
-var spawn = require('child_process').spawn;
-var sudo = require('sudo');
+var sinon = require('sinon');
 var sudoBlock = require('./sudo-block');
 
 describe('sudo-block', function () {
-	it('should prevent sudo', function (done) {
-		this.timeout(10000);
+	it('should prevent sudo', function () {
+		process.getuid = function () {
+			return 0;
+		};
 
-		var cp = sudo(['node', 'fixture.js']);
+		process.exit = sinon.spy();
+		console.error = sinon.spy();
 
-		cp.stderr.on('data', function (data) {
-			var isSudoMessage = /You are running/.test(data.toString());
-			if (isSudoMessage) {
-				assert(isSudoMessage);
-				done();
-			}
-		});
+		sudoBlock('test');
+		assert(process.exit.calledOnce);
+		assert(process.exit.calledWith(1));
 
-		cp.stdout.on('exit', function () {
-			done();
-		});
+		assert(console.error.calledOnce);
+		assert(console.error.calledWithMatch(/You are running/));
+	});
+
+	it('should not prevent users', function () {
+		process.getuid = function () {
+			return 1000;
+		};
+
+		process.exit = sinon.spy();
+		console.error = sinon.spy();
+
+		sudoBlock('test');
+		assert(!process.exit.called);
+		assert(!console.error.called);
 	});
 });


### PR DESCRIPTION
This replaces the actual calls to `console` and `process` with some stubs, so that this could also run on Travis CI. wdyt?
