### PR TITLE
Change API to take an object instead of 2nd paramter

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "colors": "~0.6.0"
   },
   "devDependencies": {
-    "mocha": "~1.9.0",
+    "mocha": "~1.11.0",
     "sinon": "~1.7.3"
   },
   "engines": {

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,17 @@ sudoBlock('my-module');
 When the above file is ran with root permissions it will exit and show an error message telling the user how to fix the problem so they don't have to run it with `sudo`.
 
 
+## API
+
+### sudoBlock(options)
+
+Options is either a string specifying the *package name* or an object with these
+keys:
+
+- `packageName`: name of the package the error message is printed for
+- `message`: a custom error message
+
+
 ## License
 
 MIT License • © [Sindre Sorhus](http://sindresorhus.com)

--- a/sudo-block.js
+++ b/sudo-block.js
@@ -5,7 +5,10 @@ function defaultMessage(packageName) {
 	return ('You are running ' + packageName.bold + ' with root permissions.').red;
 }
 
-module.exports = function (packageName, message) {
+module.exports = function (options) {
+	var packageName = typeof options === 'string' ? options : options.packageName;
+	var message = options.message;
+
 	if (process.getuid && process.getuid() === 0) {
 		console.error(message || defaultMessage(packageName));
 		process.exit(1);

--- a/test.js
+++ b/test.js
@@ -1,18 +1,20 @@
-/*global describe, it */
+/*global describe, it, beforeEach */
 'use strict';
 var assert = require('assert');
 var sinon = require('sinon');
 var sudoBlock = require('./sudo-block');
 
-describe('sudo-block', function () {
-	it('should prevent sudo', function () {
+describe('sudo mode', function () {
+	beforeEach(function () {
 		process.getuid = function () {
 			return 0;
 		};
 
 		process.exit = sinon.spy();
 		console.error = sinon.spy();
+	});
 
+	it('should prevent sudo', function () {
 		sudoBlock('test');
 		assert(process.exit.calledOnce);
 		assert(process.exit.calledWith(1));
@@ -21,14 +23,23 @@ describe('sudo-block', function () {
 		assert(console.error.calledWithMatch(/You are running/));
 	});
 
-	it('should not prevent users', function () {
+	it('accept custom messages', function () {
+		sudoBlock({ message: 'Thou shalt not sudo!' });
+		assert(console.error.calledWithMatch(/Thou shalt not sudo!/));
+	});
+});
+
+describe('user mode', function () {
+	beforeEach(function () {
 		process.getuid = function () {
 			return 1000;
 		};
 
 		process.exit = sinon.spy();
 		console.error = sinon.spy();
+	});
 
+	it('should not prevent users', function () {
 		sudoBlock('test');
 		assert(!process.exit.called);
 		assert(!console.error.called);


### PR DESCRIPTION
Since the `packageName` is ignored if you pass in your own message, wouldn't it make sense to let the function take an object instead of a second parameter?

e.g.

```
sudoBlock('yo'); // Using default message
sudoBlock({ packageName: 'yo' }); // Same as above
sudoBlock({ msg: 'Thou shalt not use sudo!' });
```
