### PR TITLE
Don't block root inside Docker containers

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,21 @@
 'use strict';
 var chalk = require('chalk');
 var isRoot = require('is-root');
+var fs = require('fs');
+
+function inDocker() {
+	try {
+		fs.statSync('/.dockerinit');
+		return true;
+	} catch (e) {
+		return false;
+	}
+}
 
 module.exports = function (message) {
 	var defaultMessage = chalk.red.bold('You are not allowed to run this app with root permissions.') + '\nIf running without ' + chalk.bold('sudo') + ' doesn\'t work, you can either fix your permission problems or change where npm stores global packages by putting ' + chalk.bold('~/npm/bin') + ' in your PATH and running:\n' + chalk.blue('npm config set prefix ~/npm') + '\n\nSee: ' + chalk.underline('https://github.com/sindresorhus/guides/blob/master/npm-global-without-sudo.md');
 
-	if (isRoot()) {
+	if (isRoot() && !inDocker()) {
 		console.error(message || defaultMessage);
 		process.exit(77);
 	}

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
+var fs = require('fs');
 var chalk = require('chalk');
 var isRoot = require('is-root');
-var fs = require('fs');
 
 function inDocker() {
 	try {

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function inDocker() {
 	try {
 		fs.statSync('/.dockerinit');
 		return true;
-	} catch (e) {
+	} catch (err) {
 		return false;
 	}
 }

--- a/test.js
+++ b/test.js
@@ -1,12 +1,17 @@
 'use strict';
 var assert = require('assert');
 var sinon = require('sinon');
+var fs = require('fs');
 var sudoBlock = require('./');
 
 describe('sudo mode', function () {
 	beforeEach(function () {
 		process.getuid = function () {
 			return 0;
+		};
+
+		fs.statSync = function () {
+			throw new Error("ENOENT, no such file or directory '/.dockerinit'")
 		};
 
 		process.exit = sinon.spy();
@@ -32,6 +37,31 @@ describe('user mode', function () {
 	beforeEach(function () {
 		process.getuid = function () {
 			return 1000;
+		};
+
+		fs.statSync = function () {
+			throw new Error("ENOENT, no such file or directory '/.dockerinit'")
+		};
+
+		process.exit = sinon.spy();
+		console.error = sinon.spy();
+	});
+
+	it('should not prevent users', function () {
+		sudoBlock();
+		assert(!process.exit.called);
+		assert(!console.error.called);
+	});
+});
+
+describe('docker mode', function () {
+	beforeEach(function () {
+		process.getuid = function () {
+			return 0;
+		};
+
+		fs.statSync = function () {
+			return {};
 		};
 
 		process.exit = sinon.spy();

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 'use strict';
 var assert = require('assert');
-var sinon = require('sinon');
 var fs = require('fs');
+var sinon = require('sinon');
 var sudoBlock = require('./');
 
 describe('sudo mode', function () {

--- a/test.js
+++ b/test.js
@@ -10,12 +10,15 @@ describe('sudo mode', function () {
 			return 0;
 		};
 
-		fs.statSync = function () {
-			throw new Error("ENOENT, no such file or directory '/.dockerinit'")
-		};
+		fs.statSync = sinon.stub(fs, 'statSync');
+		fs.statSync.withArgs('/.dockerinit').throws("ENOENT, no such file or directory '/.dockerinit'");
 
 		process.exit = sinon.spy();
 		console.error = sinon.spy();
+	});
+
+	afterEach(function () {
+		fs.statSync.restore();
 	});
 
 	it('should prevent sudo', function () {
@@ -39,12 +42,15 @@ describe('user mode', function () {
 			return 1000;
 		};
 
-		fs.statSync = function () {
-			throw new Error("ENOENT, no such file or directory '/.dockerinit'")
-		};
+		fs.statSync = sinon.stub(fs, 'statSync');
+		fs.statSync.withArgs('/.dockerinit').throws("ENOENT, no such file or directory '/.dockerinit'");
 
 		process.exit = sinon.spy();
 		console.error = sinon.spy();
+	});
+
+	afterEach(function () {
+		fs.statSync.restore();
 	});
 
 	it('should not prevent users', function () {
@@ -60,12 +66,15 @@ describe('docker mode', function () {
 			return 0;
 		};
 
-		fs.statSync = function () {
-			return {};
-		};
+		fs.statSync = sinon.stub(fs, 'statSync');
+		fs.statSync.withArgs('/.dockerinit').returns({});
 
 		process.exit = sinon.spy();
 		console.error = sinon.spy();
+	});
+
+	afterEach(function () {
+		fs.statSync.restore();
 	});
 
 	it('should not prevent users', function () {


### PR DESCRIPTION
When sudo-block is used inside a [Docker](https://www.docker.com/) container, it should probably not block. Everything inside the container runs as the *container root user*, which is not the same as the actual root user on the Docker host.

Checking if running on Docker is as simple as checking for a file called `/.dockerinit` on the file system.

Fixes https://github.com/sindresorhus/sudo-block/issues/6